### PR TITLE
🔧 Switching to go1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Build examples
         working-directory: ./examples
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Graphmasters/safedown
 
-go 1.16
+go 1.17


### PR DESCRIPTION
This pull request switches to oldest supported version i.e. go1.17. We do not use the latest version to avoid using a new feature that would force a user to update their go version. 